### PR TITLE
Update loaders.py

### DIFF
--- a/loaders.py
+++ b/loaders.py
@@ -74,7 +74,7 @@ class AudioClassifierModelEncodecBase(AudioClassifierModelBase):
         wav, sr = torchaudio.load(path)
         wav = convert_audio(wav, sr, self.model.sample_rate, self.model.channels).unsqueeze(0)
         windowed_items = torch_window(wav, sr=self.model.sample_rate, window_seconds=self.window_size, step_seconds=self.step_size).transpose(0, 2).transpose(1, 2)
-        return np.array([self.encoder(item.to("cuda:0")).detach().cpu()[0] for item in windowed_items])
+        return np.array([self.encoder(item.to("cuda:0")).detach().cpu()[0] for item in windowed_items], dtype="object")
 
 
 class AudioClassifierModelEncodec(AudioClassifierModelEncodecBase):


### PR DESCRIPTION
This change fixed training issue for 24khz model:

Processing speech_music with model 24khz ...
/software/users/talexjohn/PP4/Audio-Classification-with-EnCodec-code/venv/lib/python3.8/site-packages/torch/nn/utils/weight_norm.py:134: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.
  WeightNorm.apply(module, name, dim)
Downloading: "https://dl.fbaipublicfiles.com/encodec/v0/encodec_24khz-d7cc33bc.th" to /root/.cache/torch/hub/checkpoints/encodec_24khz-d7cc33bc.th 100.0%
datasets/GTZAN Speech_Music/speech/acomic.wav
/software/users/talexjohn/PP4/Audio-Classification-with-EnCodec-code/loaders.py:77: FutureWarning: The input object of type 'Tensor' is an array-like implementing one of the corresponding protocols (`__array__`, `__array_interface__` or `__array_struct__`); but not a sequence (or 0-D). In the future, this object will be coerced as if it was first converted using `np.array(obj)`. To retain the old behaviour, you have to either modify the type 'Tensor', or assign to an empty array created with `np.empty(correct_shape, dtype=object)`.
  return np.array([self.encoder(item.to("cuda:0")).detach().cpu()[0] for item in windowed_items])
Traceback (most recent call last):
  File "classify.py", line 13, in <module>
    perform_training(dataset, model)
  File "/software/users/talexjohn/PP4/Audio-Classification-with-EnCodec-code/utils.py", line 148, in perform_training
    X, Y = load_dataset(dataset_name, model_name, classes)
  File "/software/users/talexjohn/PP4/Audio-Classification-with-EnCodec-code/utils.py", line 45, in load_dataset
    _X = [loader_model.load(path) for path in glob.glob(glob_str)[:max_items_per_folder]]
  File "/software/users/talexjohn/PP4/Audio-Classification-with-EnCodec-code/utils.py", line 45, in <listcomp>
    _X = [loader_model.load(path) for path in glob.glob(glob_str)[:max_items_per_folder]]
  File "/software/users/talexjohn/PP4/Audio-Classification-with-EnCodec-code/loaders.py", line 77, in load
    return np.array([self.encoder(item.to("cuda:0")).detach().cpu()[0] for item in windowed_items])
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (30,) + inhomogeneous part.